### PR TITLE
Remove empty arguments

### DIFF
--- a/main.hs
+++ b/main.hs
@@ -3,6 +3,7 @@ import CabalMeta
 import OmniConfig
 import Shelly
 
+import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import Control.Monad (forM_)
 import Data.Maybe (isNothing)
@@ -54,7 +55,9 @@ nothingToFalse (Just b)  = b
 
 main :: IO ()
 main = do
-  allArgs <- allProgramOpts [commandLine, environment "cabal-meta", homeOptFile "cabal-meta"]
+  allArgs <- fmap (filter $ not . T.null) $
+    allProgramOpts [commandLine, environment "cabal-meta",
+                    homeOptFile "cabal-meta"]
   let (mDev, noDevArgs) = checkNegatedOpt "dev" allArgs
   let isDev = nothingToFalse mDev
 


### PR DESCRIPTION
I keep getting an error from cabal-meta passing a `''` argument, so this patch checks for any null options and throws them out before continuing.

(There might be a better fix for this, but I couldn’t find where these nulls were coming from…)
