### PR TITLE
Using "basename" in place of "filename" to trim .git suffix in git repository names

### DIFF
--- a/CabalMeta.hs
+++ b/CabalMeta.hs
@@ -5,7 +5,7 @@ import Shelly hiding (tag)
 import Prelude hiding (FilePath)
 import Data.Text.Lazy (Text, unpack)
 import qualified Data.Text.Lazy as T
-import Filesystem.Path.CurrentOS (hasExtension, filename)
+import Filesystem.Path.CurrentOS (hasExtension, basename)
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.List (partition)
 
@@ -91,7 +91,7 @@ readPackages allowCabals startDir = do
           chdir vendor_dir $
             forM git_pkgs $ \pkg -> do
               let repo = gitLocation pkg 
-              let d = filename $ fromText repo
+              let d = basename $ fromText repo
               e <- test_d d
               if not e
                 then git_ "clone" ["--recursive", repo]


### PR DESCRIPTION
"git clone git://example.com/repository.git" actually creates a local "repository" folder, but cabal-meta is checking "repository.git" for changes (when deciding between cloning or fetching stuff).
_Maybe_ stripping specifically ".git" suffixes would be a better solution, since basename just strips anything that follows a dot, but I think that with URIs we should follow the convention that .git (.html and others) are format specifiers and are not parts of a file (resource) name.
