### PR TITLE
add ssh: prefix for git urls in sources.txt

### DIFF
--- a/CabalMeta.hs
+++ b/CabalMeta.hs
@@ -212,6 +212,7 @@ readPackages allowCabals startDir = do
                 | prefix "http"   -> next sources { https    = mkGit: https sources }
                 | prefix "https"  -> next sources { gits     = mkGit: https sources }
                 | prefix "git:"   -> next sources { gits     = mkGit: gits sources  }
+                | prefix "ssh:"   -> next sources { gits     = mkGit: gits sources  }
                 | prefix "darcs:" -> next sources { darcsen  = mkDarcs: darcsen sources  }
                 | otherwise       -> next sources { hackages = mkPkg: hackages sources }
             where


### PR DESCRIPTION
This adds support for accessing git repos via an ssh url. Note that this does not support the more compact form used by, e.g., the github ssh URL text box. It just looks for a line in sources.txt that starts with `ssh:`
