### PR TITLE
change which path is used for cabal-dev on mingw

### DIFF
--- a/main.hs
+++ b/main.hs
@@ -35,8 +35,13 @@ cabal_install_ cabal = command_ (progName cabal) ["install"]
 data CabalExe = Cabal | CabalDev deriving Show
 
 progName :: CabalExe -> FilePath
+#ifdef mingw32_HOST_OS
+progName Cabal = "cabal.exe"
+progName CabalDev = "cabal-dev.exe"
+#else
 progName Cabal = "cabal"
 progName CabalDev = "cabal-dev"
+#endif
 
 assertCabalDependencies :: CabalExe -> IO ()
 assertCabalDependencies Cabal    = shelly $ do
@@ -45,7 +50,7 @@ assertCabalDependencies Cabal    = shelly $ do
     errorExit "please run: cabal install cabal-src"
 
 assertCabalDependencies CabalDev = do
-  mcd <- shelly $ which "cabal-dev"
+  mcd <- shelly $ which (progName CabalDev)
   case mcd of
     Just _ -> return ()
     Nothing -> error "--dev requires cabal-dev to be installed"


### PR DESCRIPTION
The Shelly implementation of `which` doesn't implicitly add a `.exe` extension, so `cabal-meta` couldn't find `cabal-dev` on Windows. This fixes it by adjusting the path used by `cabal-meta`, but perhaps the eventual fix should be having Shelly look for `.exe`s?
